### PR TITLE
Fix xrandr subprocess output capture for newer Python/xrandr versions

### DIFF
--- a/randrctl/xrandr.py
+++ b/randrctl/xrandr.py
@@ -62,15 +62,12 @@ class Xrandr:
         logger.debug("Calling xrandr with args %s", args)
         args.insert(0, self.EXECUTABLE)
 
-        p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False, env=self.env)
-        err = p.stderr.readlines()
+        p = subprocess.run(args, capture_output=True, shell=False, env=self.env)
+        err = p.stderr
         if err:
-            # close descriptors
-            p.stderr.close()
-            p.stdout.close()
-            err_str = ''.join(map(lambda x: x.decode(), err)).strip()
+            err_str = err.decode()
             raise XrandrException(err_str, args)
-        out = list(map(lambda x: x.decode(), p.stdout.readlines()))
+        out = list(map(lambda x: x.decode(), p.stdout.splitlines()))
         if out:
             out.pop(0)  # remove first line. It describes Screen
         return out


### PR DESCRIPTION
On xrandr 1.5.2 and Python 3.11, the line in `xrandr.py` to read the command error output from stderr hangs and never returns.

I fixed this issue by using the `subprocess.run` func instead of `subprocess.Popen`, using the `capture_output=True` helper kwarg, and adjusting the surrounding logic to support stdout and stderr as byte strings.